### PR TITLE
Changes to VM size and SKU reflect current best practices.

### DIFF
--- a/solutions/14_Building_Images_WVD/armTemplateWVD.json
+++ b/solutions/14_Building_Images_WVD/armTemplateWVD.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
       "imageTemplateName": {
@@ -41,15 +41,15 @@
 
             "vmProfile": 
                     {
-                    "vmSize": "Standard_D2_v2",
+                    "vmSize": "Standard_D2s_v5",
                     "osDiskSizeGB": 127
                     },
         
             "source": {
                 "type": "PlatformImage",
                     "publisher": "MicrosoftWindowsDesktop",
-                    "offer": "windows-10",
-                    "sku": "20h1-ent",
+                    "offer": "office-365",
+                    "sku": "win10-21h2-avd-m365-g2",
                     "version": "latest"
             },
             "customize": [
@@ -73,13 +73,6 @@
                         "type": "WindowsRestart",
                         "restartCheckCommand": "write-host 'restarting post Optimizations'",
                         "restartTimeout": "5m"
-                    },
-                    {
-                        "type": "PowerShell",
-                        "name": "Install Teams",
-                        "runElevated": true,
-                        "runAsSystem": true,
-                        "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/2_installTeams.ps1"
                     },
                     {
                         "type": "WindowsRestart",


### PR DESCRIPTION
I have updated the following to reflect updated best practices:

1. Schema. The existing schema is deprecated so I have updated to it to the latest version.
2. VM Size. I have changed the build VM size to use the latest version of the D-Series to match what should be used in production.
3. SKU. Microsoft have released a SKU specifically for AVD that includes Office, Teams & FSLogix. I have updated the Offer and SKU to ensure that this gets used. Side note, the FSLogix script will require updating as it will fail if used with this Offer and SKU as it is already installed. FSLogix should be downloaded and version compared to the installed version to determine if an update (uninstall then install) is required. I have submitted a pull request on danielsollondon/azvmimagebuilder to update this script so that it does not fail.
4. Teams. I have removed this as Teams machine-wide installer is included in the image.