### PR TITLE
🐛 Fix reference to main branch in Virtual-Desktop-Optimization-Tool

### DIFF
--- a/solutions/14_Building_Images_WVD/1_Optimize_OS_for_WVD.ps1
+++ b/solutions/14_Building_Images_WVD/1_Optimize_OS_for_WVD.ps1
@@ -5,17 +5,17 @@
  New-Item -Path $drive -Name $appName  -ItemType Directory -ErrorAction SilentlyContinue
  $LocalPath = $drive + '\' + $appName 
  set-Location $LocalPath
- $osOptURL = 'https://github.com/The-Virtual-Desktop-Team/Virtual-Desktop-Optimization-Tool/archive/master.zip'
- $osOptURLexe = 'Windows_10_VDI_Optimize-master.zip'
+ $osOptURL = 'https://github.com/The-Virtual-Desktop-Team/Virtual-Desktop-Optimization-Tool/archive/main.zip'
+ $osOptURLexe = 'Windows_10_VDI_Optimize-main.zip'
  $outputPath = $LocalPath + '\' + $osOptURLexe
  Invoke-WebRequest -Uri $osOptURL -OutFile $outputPath
  write-host 'AIB Customization: Starting OS Optimizations script'
- Expand-Archive -LiteralPath 'C:\\Optimize\\Windows_10_VDI_Optimize-master.zip' -DestinationPath $Localpath -Force -Verbose
+ Expand-Archive -LiteralPath 'C:\\Optimize\\Windows_10_VDI_Optimize-main.zip' -DestinationPath $Localpath -Force -Verbose
  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force -Verbose
- Set-Location -Path C:\\Optimize\\Virtual-Desktop-Optimization-Tool-master
+ Set-Location -Path C:\\Optimize\\Virtual-Desktop-Optimization-Tool-main
  
  # instrumentation
- $osOptURL = 'https://raw.githubusercontent.com/The-Virtual-Desktop-Team/Virtual-Desktop-Optimization-Tool/master/Win10_VirtualDesktop_Optimize.ps1'
+ $osOptURL = 'https://raw.githubusercontent.com/The-Virtual-Desktop-Team/Virtual-Desktop-Optimization-Tool/main/Win10_VirtualDesktop_Optimize.ps1'
  $osOptURLexe = 'optimize.ps1'
  Invoke-WebRequest -Uri $osOptURL -OutFile $osOptURLexe
  
@@ -23,7 +23,7 @@
  
  # Patch: overide the Win10_VirtualDesktop_Optimize.ps1 - setting 'Set-NetAdapterAdvancedProperty'(see readme.md)
  Write-Host 'Patch: Disabling Set-NetAdapterAdvancedProperty'
- $updatePath= "C:\optimize\Virtual-Desktop-Optimization-Tool-master\Win10_VirtualDesktop_Optimize.ps1"
+ $updatePath= "C:\optimize\Virtual-Desktop-Optimization-Tool-main\Win10_VirtualDesktop_Optimize.ps1"
  ((Get-Content -path $updatePath -Raw) -replace 'Set-NetAdapterAdvancedProperty -DisplayName "Send Buffer Size" -DisplayValue 4MB','#Set-NetAdapterAdvancedProperty -DisplayName "Send Buffer Size" -DisplayValue 4MB') | Set-Content -Path $updatePath
  
  # Patch: overide the REG UNLOAD, needs GC before, otherwise will Access Deny unload(see readme.md)


### PR DESCRIPTION
Since `The-Virtual-Desktop-Team/Virtual-Desktop-Optimization-Tool` changed their branch name to `main`, the references and file/folder names in `1_Optimize_OS_for_WVD.ps1` were invalid and didn't work. This PR fixes that.