### PR TITLE
Update armTemplateWVD.json

### DIFF
--- a/solutions/14_Building_Images_WVD/armTemplateWVD.json
+++ b/solutions/14_Building_Images_WVD/armTemplateWVD.json
@@ -60,7 +60,9 @@
                         "name": "installFsLogix",
                         "runElevated": true,
                         "runAsSystem": true,
-                        "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/0_installConfFsLogix.ps1"
+                        "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/0_installConfFsLogix.ps1",
+                        "validExitCodes": [0,267014]
+                        
                     },
                     {
                         "type": "PowerShell",


### PR DESCRIPTION
Added the exit codes 0 and 267014 as valid exit codes to the FSlogix install script block. "validExitCodes": [0,267014]

During the AVD build, the install of FSLOGIX can exit with the code 267014. This is a valid and successful exit code however because its not a common or known sucessful exit code, the build process can fail.