### PR TITLE
Update helloImageTemplateforSIG.json

### DIFF
--- a/quickquickstarts/1_Creating_a_Custom_Linux_Shared_Image_Gallery_Image/helloImageTemplateforSIG.json
+++ b/quickquickstarts/1_Creating_a_Custom_Linux_Shared_Image_Gallery_Image/helloImageTemplateforSIG.json
@@ -1,6 +1,6 @@
 {
     "type": "Microsoft.VirtualMachineImages",
-    "apiVersion": "2020-02-14",
+    "apiVersion": "2022-02-14",
     "location": "<region1>",
     "dependsOn": [],
     "tags": {
@@ -21,15 +21,15 @@
 
         "vmProfile": 
             {
-            "vmSize": "Standard_D1_v2",
+            "vmSize": "Standard_D2s_v3",
             "osDiskSizeGB": 30
             },
         
         "source": {
             "type": "PlatformImage",
                 "publisher": "Canonical",
-                "offer": "UbuntuServer",
-                "sku": "18.04-LTS",
+                "offer": "0001-com-ubuntu-server-focal",
+                "sku": "20_04-lts-gen2",
                 "version": "latest"
             
         },
@@ -80,7 +80,7 @@
                 "runOutputName": "<runOutputName>",
                 "artifactTags": {
                     "source": "azureVmImageBuilder",
-                    "baseosimg": "ubuntu1804"
+                    "baseosimg": "ubuntu2004"
                 },
                 "replicationRegions": [
                   "<region1>",


### PR DESCRIPTION
To support Trusted launch deployment in public docs example Updated following:
- API version
- OS Image - Ubuntu 18.04 -> 20.04 Gen2 LTS
- artifactTags - ubuntu1804 -> ubuntu2004

Public docs being updated:
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/image-builder